### PR TITLE
fix onKeyPress with default emoji from default keyboard

### DIFF
--- a/android/src/main/java/com/mattermost/pasteinputtext/PasteInputEditText.kt
+++ b/android/src/main/java/com/mattermost/pasteinputtext/PasteInputEditText.kt
@@ -172,8 +172,8 @@ class PasteInputEditText(context: ThemedReactContext) : ReactEditText(context) {
         // Wrap again to intercept text input for key press events
         return object : InputConnectionWrapper(wrappedIc, true) {
             override fun commitText(text: CharSequence?, newCursorPosition: Int): Boolean {
-                text?.forEach { char ->
-                    dispatchKeyPressForChar(char.toString())
+                if (!text.isNullOrEmpty()) {
+                    dispatchKeyPressForChar(text.toString())
                 }
                 return super.commitText(text, newCursorPosition)
             }


### PR DESCRIPTION
https://app.asana.com/1/1204330682799323/project/1210658194617363/task/1211492453701693?focus=true

crash log: https://gasolin.sentry.io/issues/6912808116/?alert_rule_id=14824055&alert_type=issue&notification_uuid=b126ed61-f0ef-4dc8-bdf3-4f37674151e1&project=-1&referrer=slack

fix onKeyPress with `default emoji` from `default keyboard`
related to this PR: https://github.com/holepunchto/react-native-paste-input/pull/4